### PR TITLE
Update depguard settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,8 +70,19 @@ linters-settings:
     check-shadowing: true
     enable-all: true
   depguard:
-    list-type: blacklist
-    include-go-root: false
+    rules:
+      main:
+        files:
+          - '$all'
+        allow:
+          - 'github.com/siderolabs/terraform-provider-talos/shim'
+          - 'github.com/pulumiverse/pulumi-talos/provider/pkg/version'
+          - 'github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge'
+          - 'github.com/pulumiverse/pulumi-talos/provider'
+          - 'github.com/pulumi/pulumi-terraform-bridge/pf/tfgen'
+          - 'github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge'
+          - 'github.com/pulumiverse/pulumi-talos/provider'
+          - '$gostd'
   lll:
     line-length: 200
     tab-width: 4


### PR DESCRIPTION
Linting was breaking locally for me. I'm not familiar with golangci-lint or depguard, but best I can tell from the depguard README the current settings are in a v1 format. This hopefully updates them to the v2 format golangci-lint appears to be expecting.

Again if I'm reading the docs correctly, the current config is essentially an empty blacklist. The changes I've made aren't necessarily equivalent, but I think are safer than removing depguard. Since the original settings didn't appear to be doing much, it could make sense to just remove depguard.

I also noticed d84b4da69a5e60c10c8ecff9ddabad3d2160a5cf dropped running lint in CI. Was that related? Could it be added back?