### PR TITLE
Use github scheme for plugin download url

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -42,7 +42,7 @@ func Provider() tfbridge.ProviderInfo {
 		Version:           version.Version,
 		Publisher:         "Pulumiverse",
 		LogoURL:           "https://www.talos.dev/images/Sidero_stacked_darkbkgd_RGB.png",
-		PluginDownloadURL: "https://github.com/pulumiverse/pulumi-talos/releases",
+		PluginDownloadURL: "github://api.github.com/pulumiverse/pulumi-talos",
 		MetadataInfo:      tfbridge.NewProviderMetadata(metadata),
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"talos_machine_bootstrap": {Tok: tfbridge.MakeResource(talosPkg, machineMod, "Bootstrap")},


### PR DESCRIPTION
When running a preview, I get an error that there was an error downloading the plugin.

```console
Diagnostics:
  pulumi:providers:talos (default_0_1_4_https_/github.com/pulumiverse/pulumi-talos/releases):
    error: Could not automatically download and install resource plugin 'pulumi-resource-talos' at version v0.1.4, install the plugin using `pulumi plugin install resource talos v0.1.4 --server https://github.com/pulumiverse/pulumi-talos/releases`: error downloading provider talos to file: failed to download plugin: talos-0.1.4: 404 HTTP error fetching plugin from https://github.com/pulumiverse/pulumi-talos/releases/pulumi-resource-talos-v0.1.4-linux-amd64.tar.gz
```

I'm not entirely sure why the current url doesn't work, but the github scheme works and seems appropriate.