### PR TITLE
Ignore sdk packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,10 @@
                 "golang-version"
             ],
             "groupName": "go packages"
+        },
+        {
+          "matchFileNames": ["sdk/**"],
+          "enabled": false
         }
     ],
     "dependencyDashboard": true


### PR DESCRIPTION
Since the SDKs are generated, I don't think we want bot dependency updates to them.

I took this package rule from the [pulumiverse/pulumi-vercel](https://github.com/pulumiverse/pulumi-vercel/blob/f4b76e3c2ba30c41225f9e9cad2b43e07ec60606/renovate.json#L15C1-L18C7) repo, but I would think it would still be valuable to get dep updates to `sdk/go.mod`?

Also it looks like dependabot is enabled for the org, is dependabot or renovate preferred?