### PR TITLE
Property names within `ExtraTypes` should be in Pulumi camelCase style.

### DIFF
--- a/provider/cmd/pulumi-resource-talos/schema.json
+++ b/provider/cmd/pulumi-resource-talos/schema.json
@@ -537,10 +537,10 @@
                 "k8s": {
                     "$ref": "#types/talos:machine/generated:Certificate"
                 },
-                "k8s_aggregator": {
+                "k8sAggregator": {
                     "$ref": "#types/talos:machine/generated:Certificate"
                 },
-                "k8s_serviceaccount": {
+                "k8sServiceaccount": {
                     "$ref": "#types/talos:machine/generated:Key"
                 },
                 "os": {
@@ -551,23 +551,23 @@
             "required": [
                 "etcd",
                 "k8s",
-                "k8s_aggregator",
-                "k8s_serviceaccount",
+                "k8sAggregator",
+                "k8sServiceaccount",
                 "os"
             ]
         },
         "talos:machine/generated:ClientConfiguration": {
             "description": "A Client Configuration",
             "properties": {
-                "ca_certificate": {
+                "caCertificate": {
                     "type": "string",
                     "description": "The client CA certificate"
                 },
-                "client_certificate": {
+                "clientCertificate": {
                     "type": "string",
                     "description": "The client certificate"
                 },
-                "client_key": {
+                "clientKey": {
                     "type": "string",
                     "description": "The client private key",
                     "secret": true
@@ -575,9 +575,9 @@
             },
             "type": "object",
             "required": [
-                "ca_certificate",
-                "client_certificate",
-                "client_key"
+                "caCertificate",
+                "clientCertificate",
+                "clientKey"
             ]
         },
         "talos:machine/generated:Cluster": {
@@ -616,17 +616,17 @@
         "talos:machine/generated:KubernetesSecrets": {
             "description": "A Machine Secrets Bootstrap data",
             "properties": {
-                "aescbc_encryption_secret": {
+                "aescbcEncryptionSecret": {
                     "type": "string",
                     "description": "The aescbc encryption secret for the talos kubernetes cluster",
                     "secret": true
                 },
-                "bootstrap_token": {
+                "bootstrapToken": {
                     "type": "string",
                     "description": "The bootstrap token for the talos kubernetes cluster",
                     "secret": true
                 },
-                "secretbox_encryption_secret": {
+                "secretboxEncryptionSecret": {
                     "type": "string",
                     "description": "The secretbox encryption secret for the talos kubernetes cluster",
                     "secret": true
@@ -634,8 +634,8 @@
             },
             "type": "object",
             "required": [
-                "bootstrap_token",
-                "secretbox_encryption_secret"
+                "bootstrapToken",
+                "secretboxEncryptionSecret"
             ]
         },
         "talos:machine/generated:MachineSecrets": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -109,25 +109,25 @@ func Provider() tfbridge.ProviderInfo {
 					Type:        "object",
 					Description: "A Machine Secrets Bootstrap data",
 					Properties: map[string]schema.PropertySpec{
-						"bootstrap_token": {
+						"bootstrapToken": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The bootstrap token for the talos kubernetes cluster",
 							Secret:      true,
 						},
-						"secretbox_encryption_secret": {
+						"secretboxEncryptionSecret": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The secretbox encryption secret for the talos kubernetes cluster",
 							Secret:      true,
 						},
-						"aescbc_encryption_secret": {
+						"aescbcEncryptionSecret": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The aescbc encryption secret for the talos kubernetes cluster",
 							Secret:      true,
 						},
 					},
 					Required: []string{
-						"bootstrap_token",
-						"secretbox_encryption_secret",
+						"bootstrapToken",
+						"secretboxEncryptionSecret",
 					},
 				},
 			},
@@ -162,12 +162,12 @@ func Provider() tfbridge.ProviderInfo {
 								Ref: "#types/talos:machine/generated:Certificate",
 							},
 						},
-						"k8s_aggregator": {
+						"k8sAggregator": {
 							TypeSpec: schema.TypeSpec{
 								Ref: "#types/talos:machine/generated:Certificate",
 							},
 						},
-						"k8s_serviceaccount": {
+						"k8sServiceaccount": {
 							TypeSpec: schema.TypeSpec{
 								Ref: "#types/talos:machine/generated:Key",
 							},
@@ -181,8 +181,8 @@ func Provider() tfbridge.ProviderInfo {
 					Required: []string{
 						"etcd",
 						"k8s",
-						"k8s_aggregator",
-						"k8s_serviceaccount",
+						"k8sAggregator",
+						"k8sServiceaccount",
 						"os",
 					},
 				},
@@ -192,24 +192,24 @@ func Provider() tfbridge.ProviderInfo {
 					Type:        "object",
 					Description: "A Client Configuration",
 					Properties: map[string]schema.PropertySpec{
-						"ca_certificate": {
+						"caCertificate": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The client CA certificate",
 						},
-						"client_certificate": {
+						"clientCertificate": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The client certificate",
 						},
-						"client_key": {
+						"clientKey": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The client private key",
 							Secret:      true,
 						},
 					},
 					Required: []string{
-						"ca_certificate",
-						"client_certificate",
-						"client_key",
+						"caCertificate",
+						"clientCertificate",
+						"clientKey",
 					},
 				},
 			},

--- a/sdk/dotnet/Machine/Inputs/Certificates.cs
+++ b/sdk/dotnet/Machine/Inputs/Certificates.cs
@@ -22,11 +22,11 @@ namespace Pulumiverse.Talos.Machine.Inputs
         [Input("k8s", required: true)]
         public Inputs.CertificateArgs K8s { get; set; } = null!;
 
-        [Input("k8s_aggregator", required: true)]
-        public Inputs.CertificateArgs K8s_aggregator { get; set; } = null!;
+        [Input("k8sAggregator", required: true)]
+        public Inputs.CertificateArgs K8sAggregator { get; set; } = null!;
 
-        [Input("k8s_serviceaccount", required: true)]
-        public Inputs.KeyArgs K8s_serviceaccount { get; set; } = null!;
+        [Input("k8sServiceaccount", required: true)]
+        public Inputs.KeyArgs K8sServiceaccount { get; set; } = null!;
 
         [Input("os", required: true)]
         public Inputs.CertificateArgs Os { get; set; } = null!;

--- a/sdk/dotnet/Machine/Inputs/CertificatesArgs.cs
+++ b/sdk/dotnet/Machine/Inputs/CertificatesArgs.cs
@@ -22,11 +22,11 @@ namespace Pulumiverse.Talos.Machine.Inputs
         [Input("k8s", required: true)]
         public Input<Inputs.CertificateInputArgs> K8s { get; set; } = null!;
 
-        [Input("k8s_aggregator", required: true)]
-        public Input<Inputs.CertificateInputArgs> K8s_aggregator { get; set; } = null!;
+        [Input("k8sAggregator", required: true)]
+        public Input<Inputs.CertificateInputArgs> K8sAggregator { get; set; } = null!;
 
-        [Input("k8s_serviceaccount", required: true)]
-        public Input<Inputs.KeyInputArgs> K8s_serviceaccount { get; set; } = null!;
+        [Input("k8sServiceaccount", required: true)]
+        public Input<Inputs.KeyInputArgs> K8sServiceaccount { get; set; } = null!;
 
         [Input("os", required: true)]
         public Input<Inputs.CertificateInputArgs> Os { get; set; } = null!;

--- a/sdk/dotnet/Machine/Inputs/CertificatesGetArgs.cs
+++ b/sdk/dotnet/Machine/Inputs/CertificatesGetArgs.cs
@@ -22,11 +22,11 @@ namespace Pulumiverse.Talos.Machine.Inputs
         [Input("k8s", required: true)]
         public Input<Inputs.CertificateGetArgs> K8s { get; set; } = null!;
 
-        [Input("k8s_aggregator", required: true)]
-        public Input<Inputs.CertificateGetArgs> K8s_aggregator { get; set; } = null!;
+        [Input("k8sAggregator", required: true)]
+        public Input<Inputs.CertificateGetArgs> K8sAggregator { get; set; } = null!;
 
-        [Input("k8s_serviceaccount", required: true)]
-        public Input<Inputs.KeyGetArgs> K8s_serviceaccount { get; set; } = null!;
+        [Input("k8sServiceaccount", required: true)]
+        public Input<Inputs.KeyGetArgs> K8sServiceaccount { get; set; } = null!;
 
         [Input("os", required: true)]
         public Input<Inputs.CertificateGetArgs> Os { get; set; } = null!;

--- a/sdk/dotnet/Machine/Inputs/ClientConfigurationArgs.cs
+++ b/sdk/dotnet/Machine/Inputs/ClientConfigurationArgs.cs
@@ -19,28 +19,28 @@ namespace Pulumiverse.Talos.Machine.Inputs
         /// <summary>
         /// The client CA certificate
         /// </summary>
-        [Input("ca_certificate", required: true)]
-        public Input<string> Ca_certificate { get; set; } = null!;
+        [Input("caCertificate", required: true)]
+        public Input<string> CaCertificate { get; set; } = null!;
 
         /// <summary>
         /// The client certificate
         /// </summary>
-        [Input("client_certificate", required: true)]
-        public Input<string> Client_certificate { get; set; } = null!;
+        [Input("clientCertificate", required: true)]
+        public Input<string> ClientCertificate { get; set; } = null!;
 
-        [Input("client_key", required: true)]
-        private Input<string>? _client_key;
+        [Input("clientKey", required: true)]
+        private Input<string>? _clientKey;
 
         /// <summary>
         /// The client private key
         /// </summary>
-        public Input<string>? Client_key
+        public Input<string>? ClientKey
         {
-            get => _client_key;
+            get => _clientKey;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _client_key = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _clientKey = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/sdk/dotnet/Machine/Inputs/ClientConfigurationGetArgs.cs
+++ b/sdk/dotnet/Machine/Inputs/ClientConfigurationGetArgs.cs
@@ -19,28 +19,28 @@ namespace Pulumiverse.Talos.Machine.Inputs
         /// <summary>
         /// The client CA certificate
         /// </summary>
-        [Input("ca_certificate", required: true)]
-        public Input<string> Ca_certificate { get; set; } = null!;
+        [Input("caCertificate", required: true)]
+        public Input<string> CaCertificate { get; set; } = null!;
 
         /// <summary>
         /// The client certificate
         /// </summary>
-        [Input("client_certificate", required: true)]
-        public Input<string> Client_certificate { get; set; } = null!;
+        [Input("clientCertificate", required: true)]
+        public Input<string> ClientCertificate { get; set; } = null!;
 
-        [Input("client_key", required: true)]
-        private Input<string>? _client_key;
+        [Input("clientKey", required: true)]
+        private Input<string>? _clientKey;
 
         /// <summary>
         /// The client private key
         /// </summary>
-        public Input<string>? Client_key
+        public Input<string>? ClientKey
         {
-            get => _client_key;
+            get => _clientKey;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _client_key = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _clientKey = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/sdk/dotnet/Machine/Inputs/KubernetesSecrets.cs
+++ b/sdk/dotnet/Machine/Inputs/KubernetesSecrets.cs
@@ -16,40 +16,40 @@ namespace Pulumiverse.Talos.Machine.Inputs
     /// </summary>
     public sealed class KubernetesSecretsArgs : global::Pulumi.InvokeArgs
     {
-        [Input("aescbc_encryption_secret")]
-        private string? _aescbc_encryption_secret;
+        [Input("aescbcEncryptionSecret")]
+        private string? _aescbcEncryptionSecret;
 
         /// <summary>
         /// The aescbc encryption secret for the talos kubernetes cluster
         /// </summary>
-        public string? Aescbc_encryption_secret
+        public string? AescbcEncryptionSecret
         {
-            get => _aescbc_encryption_secret;
-            set => _aescbc_encryption_secret = value;
+            get => _aescbcEncryptionSecret;
+            set => _aescbcEncryptionSecret = value;
         }
 
-        [Input("bootstrap_token", required: true)]
-        private string? _bootstrap_token;
+        [Input("bootstrapToken", required: true)]
+        private string? _bootstrapToken;
 
         /// <summary>
         /// The bootstrap token for the talos kubernetes cluster
         /// </summary>
-        public string? Bootstrap_token
+        public string? BootstrapToken
         {
-            get => _bootstrap_token;
-            set => _bootstrap_token = value;
+            get => _bootstrapToken;
+            set => _bootstrapToken = value;
         }
 
-        [Input("secretbox_encryption_secret", required: true)]
-        private string? _secretbox_encryption_secret;
+        [Input("secretboxEncryptionSecret", required: true)]
+        private string? _secretboxEncryptionSecret;
 
         /// <summary>
         /// The secretbox encryption secret for the talos kubernetes cluster
         /// </summary>
-        public string? Secretbox_encryption_secret
+        public string? SecretboxEncryptionSecret
         {
-            get => _secretbox_encryption_secret;
-            set => _secretbox_encryption_secret = value;
+            get => _secretboxEncryptionSecret;
+            set => _secretboxEncryptionSecret = value;
         }
 
         public KubernetesSecretsArgs()

--- a/sdk/dotnet/Machine/Inputs/KubernetesSecretsArgs.cs
+++ b/sdk/dotnet/Machine/Inputs/KubernetesSecretsArgs.cs
@@ -16,51 +16,51 @@ namespace Pulumiverse.Talos.Machine.Inputs
     /// </summary>
     public sealed class KubernetesSecretsInputArgs : global::Pulumi.ResourceArgs
     {
-        [Input("aescbc_encryption_secret")]
-        private Input<string>? _aescbc_encryption_secret;
+        [Input("aescbcEncryptionSecret")]
+        private Input<string>? _aescbcEncryptionSecret;
 
         /// <summary>
         /// The aescbc encryption secret for the talos kubernetes cluster
         /// </summary>
-        public Input<string>? Aescbc_encryption_secret
+        public Input<string>? AescbcEncryptionSecret
         {
-            get => _aescbc_encryption_secret;
+            get => _aescbcEncryptionSecret;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _aescbc_encryption_secret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _aescbcEncryptionSecret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 
-        [Input("bootstrap_token", required: true)]
-        private Input<string>? _bootstrap_token;
+        [Input("bootstrapToken", required: true)]
+        private Input<string>? _bootstrapToken;
 
         /// <summary>
         /// The bootstrap token for the talos kubernetes cluster
         /// </summary>
-        public Input<string>? Bootstrap_token
+        public Input<string>? BootstrapToken
         {
-            get => _bootstrap_token;
+            get => _bootstrapToken;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _bootstrap_token = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _bootstrapToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 
-        [Input("secretbox_encryption_secret", required: true)]
-        private Input<string>? _secretbox_encryption_secret;
+        [Input("secretboxEncryptionSecret", required: true)]
+        private Input<string>? _secretboxEncryptionSecret;
 
         /// <summary>
         /// The secretbox encryption secret for the talos kubernetes cluster
         /// </summary>
-        public Input<string>? Secretbox_encryption_secret
+        public Input<string>? SecretboxEncryptionSecret
         {
-            get => _secretbox_encryption_secret;
+            get => _secretboxEncryptionSecret;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _secretbox_encryption_secret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _secretboxEncryptionSecret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/sdk/dotnet/Machine/Inputs/KubernetesSecretsGetArgs.cs
+++ b/sdk/dotnet/Machine/Inputs/KubernetesSecretsGetArgs.cs
@@ -16,51 +16,51 @@ namespace Pulumiverse.Talos.Machine.Inputs
     /// </summary>
     public sealed class KubernetesSecretsGetArgs : global::Pulumi.ResourceArgs
     {
-        [Input("aescbc_encryption_secret")]
-        private Input<string>? _aescbc_encryption_secret;
+        [Input("aescbcEncryptionSecret")]
+        private Input<string>? _aescbcEncryptionSecret;
 
         /// <summary>
         /// The aescbc encryption secret for the talos kubernetes cluster
         /// </summary>
-        public Input<string>? Aescbc_encryption_secret
+        public Input<string>? AescbcEncryptionSecret
         {
-            get => _aescbc_encryption_secret;
+            get => _aescbcEncryptionSecret;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _aescbc_encryption_secret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _aescbcEncryptionSecret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 
-        [Input("bootstrap_token", required: true)]
-        private Input<string>? _bootstrap_token;
+        [Input("bootstrapToken", required: true)]
+        private Input<string>? _bootstrapToken;
 
         /// <summary>
         /// The bootstrap token for the talos kubernetes cluster
         /// </summary>
-        public Input<string>? Bootstrap_token
+        public Input<string>? BootstrapToken
         {
-            get => _bootstrap_token;
+            get => _bootstrapToken;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _bootstrap_token = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _bootstrapToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 
-        [Input("secretbox_encryption_secret", required: true)]
-        private Input<string>? _secretbox_encryption_secret;
+        [Input("secretboxEncryptionSecret", required: true)]
+        private Input<string>? _secretboxEncryptionSecret;
 
         /// <summary>
         /// The secretbox encryption secret for the talos kubernetes cluster
         /// </summary>
-        public Input<string>? Secretbox_encryption_secret
+        public Input<string>? SecretboxEncryptionSecret
         {
-            get => _secretbox_encryption_secret;
+            get => _secretboxEncryptionSecret;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _secretbox_encryption_secret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _secretboxEncryptionSecret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/sdk/dotnet/Machine/Outputs/CertificatesResult.cs
+++ b/sdk/dotnet/Machine/Outputs/CertificatesResult.cs
@@ -19,8 +19,8 @@ namespace Pulumiverse.Talos.Machine.Outputs
     {
         public readonly Outputs.CertificateResult Etcd;
         public readonly Outputs.CertificateResult K8s;
-        public readonly Outputs.CertificateResult K8s_aggregator;
-        public readonly Outputs.KeyResult K8s_serviceaccount;
+        public readonly Outputs.CertificateResult K8sAggregator;
+        public readonly Outputs.KeyResult K8sServiceaccount;
         public readonly Outputs.CertificateResult Os;
 
         [OutputConstructor]
@@ -29,16 +29,16 @@ namespace Pulumiverse.Talos.Machine.Outputs
 
             Outputs.CertificateResult k8s,
 
-            Outputs.CertificateResult k8s_aggregator,
+            Outputs.CertificateResult k8sAggregator,
 
-            Outputs.KeyResult k8s_serviceaccount,
+            Outputs.KeyResult k8sServiceaccount,
 
             Outputs.CertificateResult os)
         {
             Etcd = etcd;
             K8s = k8s;
-            K8s_aggregator = k8s_aggregator;
-            K8s_serviceaccount = k8s_serviceaccount;
+            K8sAggregator = k8sAggregator;
+            K8sServiceaccount = k8sServiceaccount;
             Os = os;
         }
     }

--- a/sdk/dotnet/Machine/Outputs/ClientConfiguration.cs
+++ b/sdk/dotnet/Machine/Outputs/ClientConfiguration.cs
@@ -20,27 +20,27 @@ namespace Pulumiverse.Talos.Machine.Outputs
         /// <summary>
         /// The client CA certificate
         /// </summary>
-        public readonly string Ca_certificate;
+        public readonly string CaCertificate;
         /// <summary>
         /// The client certificate
         /// </summary>
-        public readonly string Client_certificate;
+        public readonly string ClientCertificate;
         /// <summary>
         /// The client private key
         /// </summary>
-        public readonly string Client_key;
+        public readonly string ClientKey;
 
         [OutputConstructor]
         private ClientConfiguration(
-            string ca_certificate,
+            string caCertificate,
 
-            string client_certificate,
+            string clientCertificate,
 
-            string client_key)
+            string clientKey)
         {
-            Ca_certificate = ca_certificate;
-            Client_certificate = client_certificate;
-            Client_key = client_key;
+            CaCertificate = caCertificate;
+            ClientCertificate = clientCertificate;
+            ClientKey = clientKey;
         }
     }
 }

--- a/sdk/dotnet/Machine/Outputs/KubernetesSecretsResult.cs
+++ b/sdk/dotnet/Machine/Outputs/KubernetesSecretsResult.cs
@@ -20,27 +20,27 @@ namespace Pulumiverse.Talos.Machine.Outputs
         /// <summary>
         /// The aescbc encryption secret for the talos kubernetes cluster
         /// </summary>
-        public readonly string? Aescbc_encryption_secret;
+        public readonly string? AescbcEncryptionSecret;
         /// <summary>
         /// The bootstrap token for the talos kubernetes cluster
         /// </summary>
-        public readonly string Bootstrap_token;
+        public readonly string BootstrapToken;
         /// <summary>
         /// The secretbox encryption secret for the talos kubernetes cluster
         /// </summary>
-        public readonly string Secretbox_encryption_secret;
+        public readonly string SecretboxEncryptionSecret;
 
         [OutputConstructor]
         private KubernetesSecretsResult(
-            string? aescbc_encryption_secret,
+            string? aescbcEncryptionSecret,
 
-            string bootstrap_token,
+            string bootstrapToken,
 
-            string secretbox_encryption_secret)
+            string secretboxEncryptionSecret)
         {
-            Aescbc_encryption_secret = aescbc_encryption_secret;
-            Bootstrap_token = bootstrap_token;
-            Secretbox_encryption_secret = secretbox_encryption_secret;
+            AescbcEncryptionSecret = aescbcEncryptionSecret;
+            BootstrapToken = bootstrapToken;
+            SecretboxEncryptionSecret = secretboxEncryptionSecret;
         }
     }
 }

--- a/sdk/go/talos/machine/pulumiTypes.go
+++ b/sdk/go/talos/machine/pulumiTypes.go
@@ -2197,11 +2197,11 @@ func (o CertificatePtrOutput) Key() pulumi.StringPtrOutput {
 
 // A complete Machine Secrets Certificates configuration
 type Certificates struct {
-	Etcd               Certificate `pulumi:"etcd"`
-	K8s                Certificate `pulumi:"k8s"`
-	K8s_aggregator     Certificate `pulumi:"k8s_aggregator"`
-	K8s_serviceaccount Key         `pulumi:"k8s_serviceaccount"`
-	Os                 Certificate `pulumi:"os"`
+	Etcd              Certificate `pulumi:"etcd"`
+	K8s               Certificate `pulumi:"k8s"`
+	K8sAggregator     Certificate `pulumi:"k8sAggregator"`
+	K8sServiceaccount Key         `pulumi:"k8sServiceaccount"`
+	Os                Certificate `pulumi:"os"`
 }
 
 // CertificatesInput is an input type that accepts CertificatesArgs and CertificatesOutput values.
@@ -2217,11 +2217,11 @@ type CertificatesInput interface {
 
 // A complete Machine Secrets Certificates configuration
 type CertificatesArgs struct {
-	Etcd               CertificateInput `pulumi:"etcd"`
-	K8s                CertificateInput `pulumi:"k8s"`
-	K8s_aggregator     CertificateInput `pulumi:"k8s_aggregator"`
-	K8s_serviceaccount KeyInput         `pulumi:"k8s_serviceaccount"`
-	Os                 CertificateInput `pulumi:"os"`
+	Etcd              CertificateInput `pulumi:"etcd"`
+	K8s               CertificateInput `pulumi:"k8s"`
+	K8sAggregator     CertificateInput `pulumi:"k8sAggregator"`
+	K8sServiceaccount KeyInput         `pulumi:"k8sServiceaccount"`
+	Os                CertificateInput `pulumi:"os"`
 }
 
 func (CertificatesArgs) ElementType() reflect.Type {
@@ -2310,12 +2310,12 @@ func (o CertificatesOutput) K8s() CertificateOutput {
 	return o.ApplyT(func(v Certificates) Certificate { return v.K8s }).(CertificateOutput)
 }
 
-func (o CertificatesOutput) K8s_aggregator() CertificateOutput {
-	return o.ApplyT(func(v Certificates) Certificate { return v.K8s_aggregator }).(CertificateOutput)
+func (o CertificatesOutput) K8sAggregator() CertificateOutput {
+	return o.ApplyT(func(v Certificates) Certificate { return v.K8sAggregator }).(CertificateOutput)
 }
 
-func (o CertificatesOutput) K8s_serviceaccount() KeyOutput {
-	return o.ApplyT(func(v Certificates) Key { return v.K8s_serviceaccount }).(KeyOutput)
+func (o CertificatesOutput) K8sServiceaccount() KeyOutput {
+	return o.ApplyT(func(v Certificates) Key { return v.K8sServiceaccount }).(KeyOutput)
 }
 
 func (o CertificatesOutput) Os() CertificateOutput {
@@ -2364,21 +2364,21 @@ func (o CertificatesPtrOutput) K8s() CertificatePtrOutput {
 	}).(CertificatePtrOutput)
 }
 
-func (o CertificatesPtrOutput) K8s_aggregator() CertificatePtrOutput {
+func (o CertificatesPtrOutput) K8sAggregator() CertificatePtrOutput {
 	return o.ApplyT(func(v *Certificates) *Certificate {
 		if v == nil {
 			return nil
 		}
-		return &v.K8s_aggregator
+		return &v.K8sAggregator
 	}).(CertificatePtrOutput)
 }
 
-func (o CertificatesPtrOutput) K8s_serviceaccount() KeyPtrOutput {
+func (o CertificatesPtrOutput) K8sServiceaccount() KeyPtrOutput {
 	return o.ApplyT(func(v *Certificates) *Key {
 		if v == nil {
 			return nil
 		}
-		return &v.K8s_serviceaccount
+		return &v.K8sServiceaccount
 	}).(KeyPtrOutput)
 }
 
@@ -2394,11 +2394,11 @@ func (o CertificatesPtrOutput) Os() CertificatePtrOutput {
 // A Client Configuration
 type ClientConfiguration struct {
 	// The client CA certificate
-	Ca_certificate string `pulumi:"ca_certificate"`
+	CaCertificate string `pulumi:"caCertificate"`
 	// The client certificate
-	Client_certificate string `pulumi:"client_certificate"`
+	ClientCertificate string `pulumi:"clientCertificate"`
 	// The client private key
-	Client_key string `pulumi:"client_key"`
+	ClientKey string `pulumi:"clientKey"`
 }
 
 // ClientConfigurationInput is an input type that accepts ClientConfigurationArgs and ClientConfigurationOutput values.
@@ -2415,11 +2415,11 @@ type ClientConfigurationInput interface {
 // A Client Configuration
 type ClientConfigurationArgs struct {
 	// The client CA certificate
-	Ca_certificate pulumi.StringInput `pulumi:"ca_certificate"`
+	CaCertificate pulumi.StringInput `pulumi:"caCertificate"`
 	// The client certificate
-	Client_certificate pulumi.StringInput `pulumi:"client_certificate"`
+	ClientCertificate pulumi.StringInput `pulumi:"clientCertificate"`
 	// The client private key
-	Client_key pulumi.StringInput `pulumi:"client_key"`
+	ClientKey pulumi.StringInput `pulumi:"clientKey"`
 }
 
 func (ClientConfigurationArgs) ElementType() reflect.Type {
@@ -2501,18 +2501,18 @@ func (o ClientConfigurationOutput) ToClientConfigurationPtrOutputWithContext(ctx
 }
 
 // The client CA certificate
-func (o ClientConfigurationOutput) Ca_certificate() pulumi.StringOutput {
-	return o.ApplyT(func(v ClientConfiguration) string { return v.Ca_certificate }).(pulumi.StringOutput)
+func (o ClientConfigurationOutput) CaCertificate() pulumi.StringOutput {
+	return o.ApplyT(func(v ClientConfiguration) string { return v.CaCertificate }).(pulumi.StringOutput)
 }
 
 // The client certificate
-func (o ClientConfigurationOutput) Client_certificate() pulumi.StringOutput {
-	return o.ApplyT(func(v ClientConfiguration) string { return v.Client_certificate }).(pulumi.StringOutput)
+func (o ClientConfigurationOutput) ClientCertificate() pulumi.StringOutput {
+	return o.ApplyT(func(v ClientConfiguration) string { return v.ClientCertificate }).(pulumi.StringOutput)
 }
 
 // The client private key
-func (o ClientConfigurationOutput) Client_key() pulumi.StringOutput {
-	return o.ApplyT(func(v ClientConfiguration) string { return v.Client_key }).(pulumi.StringOutput)
+func (o ClientConfigurationOutput) ClientKey() pulumi.StringOutput {
+	return o.ApplyT(func(v ClientConfiguration) string { return v.ClientKey }).(pulumi.StringOutput)
 }
 
 type ClientConfigurationPtrOutput struct{ *pulumi.OutputState }
@@ -2540,32 +2540,32 @@ func (o ClientConfigurationPtrOutput) Elem() ClientConfigurationOutput {
 }
 
 // The client CA certificate
-func (o ClientConfigurationPtrOutput) Ca_certificate() pulumi.StringPtrOutput {
+func (o ClientConfigurationPtrOutput) CaCertificate() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ClientConfiguration) *string {
 		if v == nil {
 			return nil
 		}
-		return &v.Ca_certificate
+		return &v.CaCertificate
 	}).(pulumi.StringPtrOutput)
 }
 
 // The client certificate
-func (o ClientConfigurationPtrOutput) Client_certificate() pulumi.StringPtrOutput {
+func (o ClientConfigurationPtrOutput) ClientCertificate() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ClientConfiguration) *string {
 		if v == nil {
 			return nil
 		}
-		return &v.Client_certificate
+		return &v.ClientCertificate
 	}).(pulumi.StringPtrOutput)
 }
 
 // The client private key
-func (o ClientConfigurationPtrOutput) Client_key() pulumi.StringPtrOutput {
+func (o ClientConfigurationPtrOutput) ClientKey() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ClientConfiguration) *string {
 		if v == nil {
 			return nil
 		}
-		return &v.Client_key
+		return &v.ClientKey
 	}).(pulumi.StringPtrOutput)
 }
 
@@ -2871,11 +2871,11 @@ func (o KeyPtrOutput) Key() pulumi.StringPtrOutput {
 // A Machine Secrets Bootstrap data
 type KubernetesSecrets struct {
 	// The aescbc encryption secret for the talos kubernetes cluster
-	Aescbc_encryption_secret *string `pulumi:"aescbc_encryption_secret"`
+	AescbcEncryptionSecret *string `pulumi:"aescbcEncryptionSecret"`
 	// The bootstrap token for the talos kubernetes cluster
-	Bootstrap_token string `pulumi:"bootstrap_token"`
+	BootstrapToken string `pulumi:"bootstrapToken"`
 	// The secretbox encryption secret for the talos kubernetes cluster
-	Secretbox_encryption_secret string `pulumi:"secretbox_encryption_secret"`
+	SecretboxEncryptionSecret string `pulumi:"secretboxEncryptionSecret"`
 }
 
 // KubernetesSecretsInput is an input type that accepts KubernetesSecretsArgs and KubernetesSecretsOutput values.
@@ -2892,11 +2892,11 @@ type KubernetesSecretsInput interface {
 // A Machine Secrets Bootstrap data
 type KubernetesSecretsArgs struct {
 	// The aescbc encryption secret for the talos kubernetes cluster
-	Aescbc_encryption_secret pulumi.StringPtrInput `pulumi:"aescbc_encryption_secret"`
+	AescbcEncryptionSecret pulumi.StringPtrInput `pulumi:"aescbcEncryptionSecret"`
 	// The bootstrap token for the talos kubernetes cluster
-	Bootstrap_token pulumi.StringInput `pulumi:"bootstrap_token"`
+	BootstrapToken pulumi.StringInput `pulumi:"bootstrapToken"`
 	// The secretbox encryption secret for the talos kubernetes cluster
-	Secretbox_encryption_secret pulumi.StringInput `pulumi:"secretbox_encryption_secret"`
+	SecretboxEncryptionSecret pulumi.StringInput `pulumi:"secretboxEncryptionSecret"`
 }
 
 func (KubernetesSecretsArgs) ElementType() reflect.Type {
@@ -2978,18 +2978,18 @@ func (o KubernetesSecretsOutput) ToKubernetesSecretsPtrOutputWithContext(ctx con
 }
 
 // The aescbc encryption secret for the talos kubernetes cluster
-func (o KubernetesSecretsOutput) Aescbc_encryption_secret() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v KubernetesSecrets) *string { return v.Aescbc_encryption_secret }).(pulumi.StringPtrOutput)
+func (o KubernetesSecretsOutput) AescbcEncryptionSecret() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v KubernetesSecrets) *string { return v.AescbcEncryptionSecret }).(pulumi.StringPtrOutput)
 }
 
 // The bootstrap token for the talos kubernetes cluster
-func (o KubernetesSecretsOutput) Bootstrap_token() pulumi.StringOutput {
-	return o.ApplyT(func(v KubernetesSecrets) string { return v.Bootstrap_token }).(pulumi.StringOutput)
+func (o KubernetesSecretsOutput) BootstrapToken() pulumi.StringOutput {
+	return o.ApplyT(func(v KubernetesSecrets) string { return v.BootstrapToken }).(pulumi.StringOutput)
 }
 
 // The secretbox encryption secret for the talos kubernetes cluster
-func (o KubernetesSecretsOutput) Secretbox_encryption_secret() pulumi.StringOutput {
-	return o.ApplyT(func(v KubernetesSecrets) string { return v.Secretbox_encryption_secret }).(pulumi.StringOutput)
+func (o KubernetesSecretsOutput) SecretboxEncryptionSecret() pulumi.StringOutput {
+	return o.ApplyT(func(v KubernetesSecrets) string { return v.SecretboxEncryptionSecret }).(pulumi.StringOutput)
 }
 
 type KubernetesSecretsPtrOutput struct{ *pulumi.OutputState }
@@ -3017,32 +3017,32 @@ func (o KubernetesSecretsPtrOutput) Elem() KubernetesSecretsOutput {
 }
 
 // The aescbc encryption secret for the talos kubernetes cluster
-func (o KubernetesSecretsPtrOutput) Aescbc_encryption_secret() pulumi.StringPtrOutput {
+func (o KubernetesSecretsPtrOutput) AescbcEncryptionSecret() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *KubernetesSecrets) *string {
 		if v == nil {
 			return nil
 		}
-		return v.Aescbc_encryption_secret
+		return v.AescbcEncryptionSecret
 	}).(pulumi.StringPtrOutput)
 }
 
 // The bootstrap token for the talos kubernetes cluster
-func (o KubernetesSecretsPtrOutput) Bootstrap_token() pulumi.StringPtrOutput {
+func (o KubernetesSecretsPtrOutput) BootstrapToken() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *KubernetesSecrets) *string {
 		if v == nil {
 			return nil
 		}
-		return &v.Bootstrap_token
+		return &v.BootstrapToken
 	}).(pulumi.StringPtrOutput)
 }
 
 // The secretbox encryption secret for the talos kubernetes cluster
-func (o KubernetesSecretsPtrOutput) Secretbox_encryption_secret() pulumi.StringPtrOutput {
+func (o KubernetesSecretsPtrOutput) SecretboxEncryptionSecret() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *KubernetesSecrets) *string {
 		if v == nil {
 			return nil
 		}
-		return &v.Secretbox_encryption_secret
+		return &v.SecretboxEncryptionSecret
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -169,8 +169,8 @@ export namespace machine {
     export interface Certificates {
         etcd: inputs.machine.Certificate;
         k8s: inputs.machine.Certificate;
-        k8s_aggregator: inputs.machine.Certificate;
-        k8s_serviceaccount: inputs.machine.Key;
+        k8sAggregator: inputs.machine.Certificate;
+        k8sServiceaccount: inputs.machine.Key;
         os: inputs.machine.Certificate;
     }
 
@@ -180,8 +180,8 @@ export namespace machine {
     export interface CertificatesArgs {
         etcd: pulumi.Input<inputs.machine.CertificateArgs>;
         k8s: pulumi.Input<inputs.machine.CertificateArgs>;
-        k8s_aggregator: pulumi.Input<inputs.machine.CertificateArgs>;
-        k8s_serviceaccount: pulumi.Input<inputs.machine.KeyArgs>;
+        k8sAggregator: pulumi.Input<inputs.machine.CertificateArgs>;
+        k8sServiceaccount: pulumi.Input<inputs.machine.KeyArgs>;
         os: pulumi.Input<inputs.machine.CertificateArgs>;
     }
 
@@ -192,15 +192,15 @@ export namespace machine {
         /**
          * The client CA certificate
          */
-        ca_certificate: pulumi.Input<string>;
+        caCertificate: pulumi.Input<string>;
         /**
          * The client certificate
          */
-        client_certificate: pulumi.Input<string>;
+        clientCertificate: pulumi.Input<string>;
         /**
          * The client private key
          */
-        client_key: pulumi.Input<string>;
+        clientKey: pulumi.Input<string>;
     }
 
     /**
@@ -380,15 +380,15 @@ export namespace machine {
         /**
          * The aescbc encryption secret for the talos kubernetes cluster
          */
-        aescbc_encryption_secret?: string;
+        aescbcEncryptionSecret?: string;
         /**
          * The bootstrap token for the talos kubernetes cluster
          */
-        bootstrap_token: string;
+        bootstrapToken: string;
         /**
          * The secretbox encryption secret for the talos kubernetes cluster
          */
-        secretbox_encryption_secret: string;
+        secretboxEncryptionSecret: string;
     }
 
     /**
@@ -398,15 +398,15 @@ export namespace machine {
         /**
          * The aescbc encryption secret for the talos kubernetes cluster
          */
-        aescbc_encryption_secret?: pulumi.Input<string>;
+        aescbcEncryptionSecret?: pulumi.Input<string>;
         /**
          * The bootstrap token for the talos kubernetes cluster
          */
-        bootstrap_token: pulumi.Input<string>;
+        bootstrapToken: pulumi.Input<string>;
         /**
          * The secretbox encryption secret for the talos kubernetes cluster
          */
-        secretbox_encryption_secret: pulumi.Input<string>;
+        secretboxEncryptionSecret: pulumi.Input<string>;
     }
 
     /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -117,8 +117,8 @@ export namespace machine {
     export interface Certificates {
         etcd: outputs.machine.Certificate;
         k8s: outputs.machine.Certificate;
-        k8s_aggregator: outputs.machine.Certificate;
-        k8s_serviceaccount: outputs.machine.Key;
+        k8sAggregator: outputs.machine.Certificate;
+        k8sServiceaccount: outputs.machine.Key;
         os: outputs.machine.Certificate;
     }
 
@@ -129,15 +129,15 @@ export namespace machine {
         /**
          * The client CA certificate
          */
-        ca_certificate: string;
+        caCertificate: string;
         /**
          * The client certificate
          */
-        client_certificate: string;
+        clientCertificate: string;
         /**
          * The client private key
          */
-        client_key: string;
+        clientKey: string;
     }
 
     /**
@@ -271,15 +271,15 @@ export namespace machine {
         /**
          * The aescbc encryption secret for the talos kubernetes cluster
          */
-        aescbc_encryption_secret?: string;
+        aescbcEncryptionSecret?: string;
         /**
          * The bootstrap token for the talos kubernetes cluster
          */
-        bootstrap_token: string;
+        bootstrapToken: string;
         /**
          * The secretbox encryption secret for the talos kubernetes cluster
          */
-        secretbox_encryption_secret: string;
+        secretboxEncryptionSecret: string;
     }
 
     /**

--- a/sdk/python/pulumiverse_talos/machine/_inputs.py
+++ b/sdk/python/pulumiverse_talos/machine/_inputs.py
@@ -168,7 +168,7 @@ class CertificatesArgs:
         pulumi.set(self, "k8s", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="k8sAggregator")
     def k8s_aggregator(self) -> 'CertificateArgs':
         return pulumi.get(self, "k8s_aggregator")
 
@@ -177,7 +177,7 @@ class CertificatesArgs:
         pulumi.set(self, "k8s_aggregator", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="k8sServiceaccount")
     def k8s_serviceaccount(self) -> 'KeyArgs':
         return pulumi.get(self, "k8s_serviceaccount")
 
@@ -231,7 +231,7 @@ class CertificatesArgs:
         pulumi.set(self, "k8s", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="k8sAggregator")
     def k8s_aggregator(self) -> pulumi.Input['CertificateArgs']:
         return pulumi.get(self, "k8s_aggregator")
 
@@ -240,7 +240,7 @@ class CertificatesArgs:
         pulumi.set(self, "k8s_aggregator", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="k8sServiceaccount")
     def k8s_serviceaccount(self) -> pulumi.Input['KeyArgs']:
         return pulumi.get(self, "k8s_serviceaccount")
 
@@ -313,7 +313,7 @@ class ClientConfigurationArgs:
         pulumi.set(__self__, "client_key", client_key)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="caCertificate")
     def ca_certificate(self) -> pulumi.Input[str]:
         """
         The client CA certificate
@@ -325,7 +325,7 @@ class ClientConfigurationArgs:
         pulumi.set(self, "ca_certificate", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="clientCertificate")
     def client_certificate(self) -> pulumi.Input[str]:
         """
         The client certificate
@@ -337,7 +337,7 @@ class ClientConfigurationArgs:
         pulumi.set(self, "client_certificate", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="clientKey")
     def client_key(self) -> pulumi.Input[str]:
         """
         The client private key
@@ -489,7 +489,7 @@ class KubernetesSecretsArgs:
             pulumi.set(__self__, "aescbc_encryption_secret", aescbc_encryption_secret)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="bootstrapToken")
     def bootstrap_token(self) -> str:
         """
         The bootstrap token for the talos kubernetes cluster
@@ -501,7 +501,7 @@ class KubernetesSecretsArgs:
         pulumi.set(self, "bootstrap_token", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="secretboxEncryptionSecret")
     def secretbox_encryption_secret(self) -> str:
         """
         The secretbox encryption secret for the talos kubernetes cluster
@@ -513,7 +513,7 @@ class KubernetesSecretsArgs:
         pulumi.set(self, "secretbox_encryption_secret", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="aescbcEncryptionSecret")
     def aescbc_encryption_secret(self) -> Optional[str]:
         """
         The aescbc encryption secret for the talos kubernetes cluster
@@ -543,7 +543,7 @@ class KubernetesSecretsArgs:
             pulumi.set(__self__, "aescbc_encryption_secret", aescbc_encryption_secret)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="bootstrapToken")
     def bootstrap_token(self) -> pulumi.Input[str]:
         """
         The bootstrap token for the talos kubernetes cluster
@@ -555,7 +555,7 @@ class KubernetesSecretsArgs:
         pulumi.set(self, "bootstrap_token", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="secretboxEncryptionSecret")
     def secretbox_encryption_secret(self) -> pulumi.Input[str]:
         """
         The secretbox encryption secret for the talos kubernetes cluster
@@ -567,7 +567,7 @@ class KubernetesSecretsArgs:
         pulumi.set(self, "secretbox_encryption_secret", value)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="aescbcEncryptionSecret")
     def aescbc_encryption_secret(self) -> Optional[pulumi.Input[str]]:
         """
         The aescbc encryption secret for the talos kubernetes cluster

--- a/sdk/python/pulumiverse_talos/machine/outputs.py
+++ b/sdk/python/pulumiverse_talos/machine/outputs.py
@@ -115,6 +115,25 @@ class CertificatesResult(dict):
     """
     A complete Machine Secrets Certificates configuration
     """
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "k8sAggregator":
+            suggest = "k8s_aggregator"
+        elif key == "k8sServiceaccount":
+            suggest = "k8s_serviceaccount"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in CertificatesResult. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        CertificatesResult.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        CertificatesResult.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  etcd: 'outputs.CertificateResult',
                  k8s: 'outputs.CertificateResult',
@@ -141,12 +160,12 @@ class CertificatesResult(dict):
         return pulumi.get(self, "k8s")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="k8sAggregator")
     def k8s_aggregator(self) -> 'outputs.CertificateResult':
         return pulumi.get(self, "k8s_aggregator")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="k8sServiceaccount")
     def k8s_serviceaccount(self) -> 'outputs.KeyResult':
         return pulumi.get(self, "k8s_serviceaccount")
 
@@ -161,6 +180,27 @@ class ClientConfiguration(dict):
     """
     A Client Configuration
     """
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "caCertificate":
+            suggest = "ca_certificate"
+        elif key == "clientCertificate":
+            suggest = "client_certificate"
+        elif key == "clientKey":
+            suggest = "client_key"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in ClientConfiguration. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        ClientConfiguration.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        ClientConfiguration.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  ca_certificate: str,
                  client_certificate: str,
@@ -176,7 +216,7 @@ class ClientConfiguration(dict):
         pulumi.set(__self__, "client_key", client_key)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="caCertificate")
     def ca_certificate(self) -> str:
         """
         The client CA certificate
@@ -184,7 +224,7 @@ class ClientConfiguration(dict):
         return pulumi.get(self, "ca_certificate")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="clientCertificate")
     def client_certificate(self) -> str:
         """
         The client certificate
@@ -192,7 +232,7 @@ class ClientConfiguration(dict):
         return pulumi.get(self, "client_certificate")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="clientKey")
     def client_key(self) -> str:
         """
         The client private key
@@ -260,6 +300,27 @@ class KubernetesSecretsResult(dict):
     """
     A Machine Secrets Bootstrap data
     """
+    @staticmethod
+    def __key_warning(key: str):
+        suggest = None
+        if key == "bootstrapToken":
+            suggest = "bootstrap_token"
+        elif key == "secretboxEncryptionSecret":
+            suggest = "secretbox_encryption_secret"
+        elif key == "aescbcEncryptionSecret":
+            suggest = "aescbc_encryption_secret"
+
+        if suggest:
+            pulumi.log.warn(f"Key '{key}' not found in KubernetesSecretsResult. Access the value via the '{suggest}' property getter instead.")
+
+    def __getitem__(self, key: str) -> Any:
+        KubernetesSecretsResult.__key_warning(key)
+        return super().__getitem__(key)
+
+    def get(self, key: str, default = None) -> Any:
+        KubernetesSecretsResult.__key_warning(key)
+        return super().get(key, default)
+
     def __init__(__self__, *,
                  bootstrap_token: str,
                  secretbox_encryption_secret: str,
@@ -276,7 +337,7 @@ class KubernetesSecretsResult(dict):
             pulumi.set(__self__, "aescbc_encryption_secret", aescbc_encryption_secret)
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="bootstrapToken")
     def bootstrap_token(self) -> str:
         """
         The bootstrap token for the talos kubernetes cluster
@@ -284,7 +345,7 @@ class KubernetesSecretsResult(dict):
         return pulumi.get(self, "bootstrap_token")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="secretboxEncryptionSecret")
     def secretbox_encryption_secret(self) -> str:
         """
         The secretbox encryption secret for the talos kubernetes cluster
@@ -292,7 +353,7 @@ class KubernetesSecretsResult(dict):
         return pulumi.get(self, "secretbox_encryption_secret")
 
     @property
-    @pulumi.getter
+    @pulumi.getter(name="aescbcEncryptionSecret")
     def aescbc_encryption_secret(self) -> Optional[str]:
         """
         The aescbc encryption secret for the talos kubernetes cluster


### PR DESCRIPTION
The names of properties in some of the SDKs were wrong because the name used within `ExtraTypes` section in `provider/resources.go` must be Pulumi `camelCase` style instead of Terraform `under_score` style.

Context:
https://github.com/pulumi/pulumi-terraform-bridge/issues/1786#issuecomment-2020757588