### PR TITLE
Bump Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARTIFACTS ?= _out
 
 .PHONY: development provider build_sdks build_nodejs build_dotnet build_go build_python cleanup
 
-development:: install_plugins provider lint_provider build_sdks install_sdks cleanup # Build the provider & SDKs for a development environment
+development:: install_plugins provider build_sdks install_sdks cleanup # Build the provider & SDKs for a development environment
 
 # Required for the codegen action that runs in pulumi/pulumi and pulumi/pulumi-terraform-bridge
 build:: install_plugins provider build_sdks install_sdks

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,3 +1,3 @@
 module github.com/pulumiverse/pulumi-talos/examples
 
-go 1.20
+go 1.22

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,8 +1,6 @@
 module github.com/pulumiverse/pulumi-talos/provider
 
-go 1.21.12
-
-toolchain go1.21.13
+go 1.22
 
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumiverse/pulumi-talos/sdk
 
-go 1.21.5
+go 1.22
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
This PR bumps the Go SDK version to 1.22. This matches what we have configured in `main.yml` and `release.yml`, and is what I think I've seen as the minimum supported version in other providers.

This also removes the `lint_provider` dep from the default `development` make target. There are currently linting errors so just running `make` will fail. I've got another PR where I'm hoping to clean those up.

<details>
<summary>Lint errors</summary>

![image](https://github.com/user-attachments/assets/9eedabf6-fca4-4751-b649-81f9975790e8)
</details>
