### PR TITLE
Mux in a native provider

### DIFF
--- a/provider/native/machine/secrets.go
+++ b/provider/native/machine/secrets.go
@@ -1,0 +1,28 @@
+package machine
+
+import (
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type Secrets struct {
+	pulumi.ResourceState
+	SecretsArgs
+	HardcodedOutput pulumi.StringOutput `pulumi:"hardcodedOutput"`
+}
+
+type SecretsArgs struct {
+}
+
+// NewSecrets creates a new instance of the Secrets resource.
+func NewSecrets(ctx *pulumi.Context, name string, compArgs *SecretsArgs, opts ...pulumi.ResourceOption) (*Secrets, error) {
+	comp := &Secrets{}
+	err := ctx.RegisterComponentResource(p.GetTypeToken(ctx.Context()), name, comp, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	comp.HardcodedOutput = pulumi.String("This is a hardcoded output string from a nested module.").ToStringOutput()
+
+	return comp, nil
+}

--- a/provider/native/provider.go
+++ b/provider/native/provider.go
@@ -2,37 +2,43 @@ package native
 
 import (
 	"context"
+	"fmt"
 
-	gop "github.com/pulumi/pulumi-go-provider"
+	goprovider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumiverse/pulumi-talos/provider/native/machine"
 )
 
 type Provider struct {
-	prov gop.Provider
+	prov goprovider.Provider
 }
 
 func NewProvider() *Provider {
 	inst := Provider{}
-	inst.prov = infer.Provider(infer.Options{
-		Functions: []infer.InferredFunction{},
-		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{
-			"native": "index",
-		},
-	})
+	prov, err := infer.NewProviderBuilder().
+		WithNamespace("talos").
+		WithComponents(
+			infer.ComponentF(machine.NewSecrets),
+		).
+		Build()
+	if err != nil {
+		panic(fmt.Errorf("Error in infer.NewProviderBuilder: %w", err))
+	}
+	inst.prov = prov
 	return &inst
 }
 
 func (p *Provider) GetSpec(ctx context.Context, name, version string) (schema.PackageSpec, error) {
-	return gop.GetSchema(ctx, name, version, p.prov)
+	return goprovider.GetSchema(ctx, name, version, p.prov)
 }
 
 func (p *Provider) GetInstance(
 	_ context.Context, name,
 	version string,
 	host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-	return gop.RawServer(name, version, p.prov)(host)
+	return goprovider.RawServer(name, version, p.prov)(host)
 }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -19,6 +19,7 @@ import (
 	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
+	"github.com/pulumiverse/pulumi-talos/provider/native"
 	"github.com/pulumiverse/pulumi-talos/provider/pkg/version"
 )
 
@@ -52,9 +53,9 @@ func Provider() tfbridge.ProviderInfo {
 		LogoURL:           "https://raw.githubusercontent.com/pulumiverse/pulumi-talos/refs/heads/main/assets/talos-logo.png",
 		PluginDownloadURL: "github://api.github.com/pulumiverse",
 		MetadataInfo:      tfbridge.NewProviderMetadata(metadata),
-		//MuxWith: []tfbridge.MuxProvider{
-		//	native.NewProvider(),
-		//},
+		MuxWith: []tfbridge.MuxProvider{
+			native.NewProvider(),
+		},
 		ExtraTypes: map[string]schema.ComplexTypeSpec{
 			"talos:machine/generated:Key": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{


### PR DESCRIPTION
Activate a muxed provider. The muxed provider wraps a native provider implemented with `pulumi-go-provider`.